### PR TITLE
Add `MESSAGE_STOP` constant to declare end of message

### DIFF
--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -60,7 +60,7 @@ void Game::update(double deltaTime) {
         Vector2 pos = player->getPos();
         Gridpoint *gp = m_grid->getPoint(pos.x + 1, pos.y + 1);
 
-        std::string command = "PLAYER_UPDATE_POSITION;" + std::to_string(m_myPid) + ";" + std::to_string(gp->getGridPointX() / m_grid->getGridPointWidth()) + ";" + std::to_string(gp->getGridPointY() / m_grid->getGridPointHeight());
+        std::string command = "PLAYER_UPDATE_POSITION;" + std::to_string(m_myPid) + ";" + std::to_string(gp->getGridPointX() / m_grid->getGridPointWidth()) + ";" + std::to_string(gp->getGridPointY() / m_grid->getGridPointHeight()) + MESSAGE_STOP;
 
         if (command != m_lastPosition) {
             // std::cout << command << std::endl;
@@ -367,3 +367,4 @@ void Game::loadTextures() {
     m_gui->loadAtlas(TextureID::A_GREEN_SNAKE, "snakes/g_s.png", 16, 16, 4);
     m_gui->loadAtlas(TextureID::A_RED_SNAKE, "snakes/r_s.png", 16, 16, 4);
 }
+

--- a/src/headers/Controller.hpp
+++ b/src/headers/Controller.hpp
@@ -13,6 +13,8 @@
 #include "Client_interface.hpp"
 #include "Observer.hpp"
 
+inline const std::string MESSAGE_STOP = ";;;";
+
 void getIpAdressAndPort(std::string &ip, int &port);
 void getName(std::string &name);
 void getColor(std::string &color);


### PR DESCRIPTION
To avoid two messages being read as one which was partly time-based we add `;;;` at the end of each message to signal a stop. Not implemented on server yet but seems to have resolved the most urgent issue. #38